### PR TITLE
Upgrade .NET Framework to 4.8. Add support for TLS 1.2+ (#1)

### DIFF
--- a/.github/workflows/buid.yml
+++ b/.github/workflows/buid.yml
@@ -4,14 +4,14 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 
       - name: Install .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2

--- a/BooScriptExecutorFactory/BooScriptExecutorFactory.csproj
+++ b/BooScriptExecutorFactory/BooScriptExecutorFactory.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Org.IdentityConnectors.Common.Script.Boo</RootNamespace>
     <AssemblyName>Boo.ScriptExecutorFactory</AssemblyName>
     <ProductName>Boo ScriptExecutor Factory</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Org.IdentityConnectors.Common</RootNamespace>
     <AssemblyName>Common</AssemblyName>
     <ProductName>Open Connectors Common</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
     <WarningLevel>4</WarningLevel>

--- a/ConnectorServerService/ConnectorServerService.csproj
+++ b/ConnectorServerService/ConnectorServerService.csproj
@@ -5,19 +5,19 @@
 
   Copyright (c) 2015 ForgeRock AS. All rights reserved.
 
-  The contents of this file are subject to the terms of the Common Development 
-  and Distribution License("CDDL") (the "License").  You may not use this file 
+  The contents of this file are subject to the terms of the Common Development
+  and Distribution License("CDDL") (the "License").  You may not use this file
   except in compliance with the License.
-  
-  You can obtain a copy of the License at 
+
+  You can obtain a copy of the License at
   http://opensource.org/licenses/CDDL-1.0
-  See the License for the specific language governing permissions and limitations 
-  under the License. 
-  
+  See the License for the specific language governing permissions and limitations
+  under the License.
+
   When distributing the Covered Code, include this CDDL Header Notice in each file
   and include the License file at legal/CDDLv1.txt.
-  If applicable, add the following below this CDDL Header, with the fields 
-  enclosed by brackets [] replaced by your own identifying information: 
+  If applicable, add the following below this CDDL Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
   "Portions Copyrighted [year] [name of copyright owner]"
   ====================
 -->
@@ -32,7 +32,7 @@
     <RootNamespace>Org.ForgeRock.OpenICF.Framework.ConnectorServerService</RootNamespace>
     <AssemblyName>ConnectorServerService</AssemblyName>
     <ProductName>OpenICF Framework - Connector Server Service</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <WcfConfigValidationEnabled>True</WcfConfigValidationEnabled>

--- a/ConnectorServerService/packages.config
+++ b/ConnectorServerService/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net45" />
-  <package id="vtortola.WebSocketListener" version="2.1.9.0" targetFramework="net45" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net48" />
+  <package id="vtortola.WebSocketListener" version="2.1.9.0" targetFramework="net48" />
 </packages>

--- a/Framework/Framework.csproj
+++ b/Framework/Framework.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Org.IdentityConnectors.Framework</RootNamespace>
     <AssemblyName>Framework</AssemblyName>
     <ProductName>Open Connectors Framework</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
     <WarningLevel>4</WarningLevel>

--- a/FrameworkInternal/ApiRemote.cs
+++ b/FrameworkInternal/ApiRemote.cs
@@ -1,22 +1,22 @@
 /*
  * ====================
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.     
- * 
- * The contents of this file are subject to the terms of the Common Development 
- * and Distribution License("CDDL") (the "License").  You may not use this file 
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
  * except in compliance with the License.
- * 
- * You can obtain a copy of the License at 
+ *
+ * You can obtain a copy of the License at
  * http://opensource.org/licenses/cddl1.php
- * See the License for the specific language governing permissions and limitations 
- * under the License. 
- * 
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
  * When distributing the Covered Code, include this CDDL Header Notice in each file
  * and include the License file at http://opensource.org/licenses/cddl1.php.
- * If applicable, add the following below this CDDL Header, with the fields 
- * enclosed by brackets [] replaced by your own identifying information: 
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2012-2015 ForgeRock AS.
@@ -99,7 +99,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Remote
                     }
                     ((SslStream)stream).AuthenticateAsClient(connectionInfo.Host,
                                                                  new X509CertificateCollection(new X509Certificate[0]),
-                                                            SslProtocols.Tls,
+                                                            SslProtocols.None,
                                                             false);
                 }
             }
@@ -296,7 +296,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Remote
         {
             if (api.RawType == typeof(IConnectorEventSubscriptionApiOp) || api.RawType == typeof(ISyncEventSubscriptionApiOp))
             {
-                //Not supported remotely with legacy communication protocol 
+                //Not supported remotely with legacy communication protocol
                 return null;
             }
             // add remote proxy
@@ -479,15 +479,15 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Remote
     /// <p/>
     /// <b>This Exception is not allowed to use in Connectors!!!</b>
     /// <p/>
-    /// 
-    /// 
-    /// 
+    ///
+    ///
+    ///
     /// This type of exception is not allowed to be serialise because this exception
     /// represents any after deserialization.
-    /// 
+    ///
     /// This code example show how to get the remote stack trace and how to use the
     /// same catches to handle the exceptions regardless its origin.
-    /// 
+    ///
     /// <pre>
     /// <code>
     ///  String stackTrace = null;
@@ -498,7 +498,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Remote
     ///          stackTrace = e.StackTrace;
     ///      }
     ///  } catch (Throwable t) {
-    ///      
+    ///
     ///  }
     /// <code>
     /// </pre>
@@ -561,7 +561,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Remote
 
         /// <summary>
         /// Gets the class name of the original exception.
-        /// 
+        ///
         /// This value is constructed by {@code Exception.Type.FullName}.
         /// </summary>
         /// <returns> name of the original exception. </returns>

--- a/FrameworkInternal/FrameworkInternal.csproj
+++ b/FrameworkInternal/FrameworkInternal.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Org.IdentityConnectors</RootNamespace>
     <AssemblyName>FrameworkInternal</AssemblyName>
     <ProductName>Open Connectors Framework Internal</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
     <WarningLevel>4</WarningLevel>

--- a/FrameworkInternal/Server.cs
+++ b/FrameworkInternal/Server.cs
@@ -1,22 +1,22 @@
 /*
  * ====================
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
- * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.     
- * 
- * The contents of this file are subject to the terms of the Common Development 
- * and Distribution License("CDDL") (the "License").  You may not use this file 
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
  * except in compliance with the License.
- * 
- * You can obtain a copy of the License at 
+ *
+ * You can obtain a copy of the License at
  * http://opensource.org/licenses/cddl1.php
- * See the License for the specific language governing permissions and limitations 
- * under the License. 
- * 
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
  * When distributing the Covered Code, include this CDDL Header Notice in each file
  * and include the License file at http://opensource.org/licenses/cddl1.php.
- * If applicable, add the following below this CDDL Header, with the fields 
- * enclosed by brackets [] replaced by your own identifying information: 
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2012-2014 ForgeRock AS.
@@ -69,7 +69,7 @@ namespace Org.IdentityConnectors.Framework.Server
         /// <summary>
         /// Base 64 sha1 hash of the connector server key
         /// </summary>
-        /// 
+        ///
         private String _keyHash;
 
         /// <summary>
@@ -683,7 +683,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Server
         /// <summary>
         /// When arguments are serialized, we loose the
         /// generic-type of collections. We must fix
-        /// the arguments 
+        /// the arguments
         /// </summary>
         /// <param name="method"></param>
         /// <param name="args"></param>
@@ -813,7 +813,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Server
             _socket = socket;
             _thisThread = new Thread(Run) { Name = "ConnectionListener", IsBackground = false };
             //TODO: thread pool
-            /*            _threadPool = 
+            /*            _threadPool =
                             new ThreadPoolExecutor
                             (server.getMinWorkers(),
                              server.getMaxWorkers(),
@@ -848,7 +848,7 @@ namespace Org.IdentityConnectors.Framework.Impl.Server
                             stream = sslStream;
                             sslStream.AuthenticateAsServer(_server.ServerCertificate,
                                                            false,
-                                                           SslProtocols.Tls,
+                                                           SslProtocols.None,
                                                            false);
                         }
 
@@ -1072,9 +1072,9 @@ namespace Org.IdentityConnectors.Framework.Impl.Server
             ConnectorInfoManagerFactory.GetInstance().GetLocalManager();
             _requestCount = 0;
             /*
-             * the Java and .Net dates have a different starting point: zero milliseconds in Java corresponds to January 1, 1970, 00:00:00 GMT (aka “the epoch”). 
-             * In .Net zero milliseconds* corresponds to 12:00 A.M., January 1, 0001 GMT. 
-             * So the basic is to bridge over the reference points gap with adding (or substracting) the corresponding number of milliseconds 
+             * the Java and .Net dates have a different starting point: zero milliseconds in Java corresponds to January 1, 1970, 00:00:00 GMT (aka the epoch).
+             * In .Net zero milliseconds* corresponds to 12:00 A.M., January 1, 0001 GMT.
+             * So the basic is to bridge over the reference points gap with adding (or substracting) the corresponding number of milliseconds
              * such that zero milliseconds in .Net is mapped to -62135769600000L milliseconds in Java.
              * This number of milliseconds corresponds to GMT zone, so do not forget to include your time zone offset into the calculations.
              */

--- a/FrameworkProtoBuf/FrameworkProtoBuf.csproj
+++ b/FrameworkProtoBuf/FrameworkProtoBuf.csproj
@@ -32,7 +32,7 @@
     <RootNamespace>Org.ForgeRock.OpenICF.Common.ProtoBuf</RootNamespace>
     <AssemblyName>FrameworkProtoBuf</AssemblyName>
     <ProductName>OpenICF Framework - Protocol Buffer Messages</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/FrameworkRPC/FrameworkRpc.csproj
+++ b/FrameworkRPC/FrameworkRpc.csproj
@@ -32,7 +32,7 @@
     <RootNamespace>Org.ForgeRock.OpenICF.Common.Rpc</RootNamespace>
     <AssemblyName>FrameworkRpc</AssemblyName>
     <ProductName>OpenICF Framework - Remote Procedure Call API</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/FrameworkServer/FrameworkServer.csproj
+++ b/FrameworkServer/FrameworkServer.csproj
@@ -5,19 +5,19 @@
 
   Copyright (c) 2015 ForgeRock AS. All rights reserved.
 
-  The contents of this file are subject to the terms of the Common Development 
-  and Distribution License("CDDL") (the "License").  You may not use this file 
+  The contents of this file are subject to the terms of the Common Development
+  and Distribution License("CDDL") (the "License").  You may not use this file
   except in compliance with the License.
-  
-  You can obtain a copy of the License at 
+
+  You can obtain a copy of the License at
   http://opensource.org/licenses/CDDL-1.0
-  See the License for the specific language governing permissions and limitations 
-  under the License. 
-  
+  See the License for the specific language governing permissions and limitations
+  under the License.
+
   When distributing the Covered Code, include this CDDL Header Notice in each file
   and include the License file at legal/CDDLv1.txt.
-  If applicable, add the following below this CDDL Header, with the fields 
-  enclosed by brackets [] replaced by your own identifying information: 
+  If applicable, add the following below this CDDL Header, with the fields
+  enclosed by brackets [] replaced by your own identifying information:
   "Portions Copyrighted [year] [name of copyright owner]"
   ====================
 -->
@@ -32,7 +32,7 @@
     <RootNamespace>Org.ForgeRock.OpenICF.Framework.Remote</RootNamespace>
     <AssemblyName>FrameworkServer</AssemblyName>
     <ProductName>OpenICF Framework - Connector Server</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
     <TargetFrameworkProfile />
@@ -56,8 +56,8 @@
   </PropertyGroup>
   <Import Project="$(MSBuildProjectDirectory)\..\Framework.targets" />
   <ItemGroup>
-    <Reference Include="crypto">
-      <HintPath>..\packages\BouncyCastle.Crypto.1.8.0-beta4\lib\net40\crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Crypto">
+      <HintPath>..\packages\BouncyCastle.1.8.9\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="Google.Protobuf">
       <HintPath>..\packages\Google.ProtocolBuffers.3\lib\Google.Protobuf.dll</HintPath>

--- a/FrameworkServer/packages.config
+++ b/FrameworkServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle.Crypto" version="1.8.0-beta4" targetFramework="net45" />
+  <package id="BouncyCastle" version="1.8.9" targetFramework="net48" />
 </packages>

--- a/FrameworkServerTests/FrameworkServerTests.csproj
+++ b/FrameworkServerTests/FrameworkServerTests.csproj
@@ -32,7 +32,7 @@
     <RootNamespace>Org.ForgeRock.OpenICF.Framework.Remote</RootNamespace>
     <AssemblyName>FrameworkServerTests</AssemblyName>
     <ProductName>OpenICF Framework - Connector Server Tests</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TestProjectType>UnitTest</TestProjectType>
@@ -66,21 +66,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    <Reference Include="System.Reactive, Version=6.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.6.0.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Channels" />

--- a/FrameworkServerTests/packages.config
+++ b/FrameworkServerTests/packages.config
@@ -1,8 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.Reactive" version="6.0.0" targetFramework="net48" />
 </packages>

--- a/FrameworkTests/FrameworkTests.csproj
+++ b/FrameworkTests/FrameworkTests.csproj
@@ -31,7 +31,7 @@
     <RootNamespace>FrameworkTests</RootNamespace>
     <AssemblyName>FrameworkTests</AssemblyName>
     <ProductName>FrameworkTests</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <NunitPath>$(SolutionDir)\NUnit.Runners.2.6.7\tools</NunitPath>
   </PropertyGroup>
@@ -69,21 +69,8 @@
     <Reference Include="System.Data.DataSetExtensions">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    <Reference Include="System.Reactive, Version=6.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reactive.6.0.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq">

--- a/FrameworkTests/packages.config
+++ b/FrameworkTests/packages.config
@@ -1,8 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
-  <package id="Rx-Main" version="2.2.5" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.Reactive" version="6.0.0" targetFramework="net48" />
 </packages>

--- a/PowerShellScriptExecutorFactory/PowerShellScriptExecutorFactory.csproj
+++ b/PowerShellScriptExecutorFactory/PowerShellScriptExecutorFactory.csproj
@@ -34,7 +34,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Org.ForgeRock.OpenICF.Framework.Common.Script.PowerShell</RootNamespace>
     <AssemblyName>PowerShell.ScriptExecutorFactory</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CopyOutput>true</CopyOutput>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Org.IdentityConnectors.Framework.Service</RootNamespace>
     <AssemblyName>ConnectorServer</AssemblyName>
     <ProductName>Open Connectors Framework - Connector Server Service</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NoStdLib>False</NoStdLib>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <TargetFrameworkProfile />

--- a/ServiceInstall/Setup.wxs
+++ b/ServiceInstall/Setup.wxs
@@ -12,8 +12,8 @@
                  InstallerVersion="200"
                  Compressed="yes"/>
         <!--
-            Source media for the installation. 
-             Specifies a single cab file to be embedded in the installer's .msi. 
+            Source media for the installation.
+             Specifies a single cab file to be embedded in the installer's .msi.
         -->
         <Media Id="1" Cabinet="contents.cab" EmbedCab="yes" CompressionLevel="high"/>
 
@@ -91,10 +91,8 @@
                         <Component Id="ConnectorServerServiceComponent" Guid="8B1F7E82-46D7-4F88-A1FA-44FCBF7E685F"
                                    DiskId="1">
 
-                            <File Source="$(var.ConnectorServerService.TargetDir)crypto.dll"
-                                  Name="crypto.dll"/>
-                            <File Source="$(var.ConnectorServerService.TargetDir)crypto.xml"
-                                  Name="crypto.xml"/>
+                            <File Source="$(var.ConnectorServerService.TargetDir)BouncyCastle.Crypto.dll"
+                                  Name="BouncyCastle.Crypto.dll"/>
                             <File Source="$(var.ConnectorServerService.TargetDir)FrameworkProtoBuf.dll"
                                   Name="FrameworkProtoBuf.dll"/>
                             <File Source="$(var.ConnectorServerService.TargetDir)FrameworkProtoBuf.pdb"

--- a/ShellScriptExecutorFactory/ShellScriptExecutorFactory.csproj
+++ b/ShellScriptExecutorFactory/ShellScriptExecutorFactory.csproj
@@ -30,7 +30,7 @@
     <RootNamespace>Sun.OpenConnectors.Common.Script.Shell</RootNamespace>
     <AssemblyName>Shell.ScriptExecutorFactory</AssemblyName>
     <ProductName>ShellScriptExecutorFactory</ProductName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <CopyOutput>true</CopyOutput>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/TestBundles/TestBundleV1/TestBundleV1.csproj
+++ b/TestBundles/TestBundleV1/TestBundleV1.csproj
@@ -29,7 +29,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestBundleV1</RootNamespace>
     <AssemblyName>TestBundleV1.Connector</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/TestBundles/TestBundleV2/TestBundleV2.csproj
+++ b/TestBundles/TestBundleV2/TestBundleV2.csproj
@@ -29,7 +29,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>TestBundleV2</RootNamespace>
     <AssemblyName>TestBundleV2.Connector</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/TestCommon/TestCommon.csproj
+++ b/TestCommon/TestCommon.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Org.IdentityConnectors.Test.Common</RootNamespace>
     <AssemblyName>TestCommon</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <InternalsVisibleTo>FrameworkTests</InternalsVisibleTo>
     <CopyOutput>true</CopyOutput>

--- a/WcfServiceLibrary/WcfServiceLibrary.csproj
+++ b/WcfServiceLibrary/WcfServiceLibrary.csproj
@@ -35,7 +35,7 @@
     <AssemblyName>WcfServiceLibrary</AssemblyName>
     <ProductName>OpenICF Framework - WCF Service Library</ProductName>
     <ProjectTypeGuids>{3D9AD99F-2412-4246-B90B-4EAA41C64699};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This PR updates the target framework version to 4.8 and also adds support for TLS version 1.2 and higher. The `SslProtocols.None` option is now used to allow the operating system to select the optimal protocol version. Starting with version 4.7, the .NET Framework itself should enforce this behavior.

I successfully tested the PowerShell connector that was deployed in the new Connector Server build. The connection between IdM and Connector server was secured using TLS 1.2.